### PR TITLE
Fix code issues using JSHint

### DIFF
--- a/app/.xsaccess
+++ b/app/.xsaccess
@@ -1,21 +1,21 @@
 {
-     "exposed" : true,  
-                  
-     "authentication" :                                            
-            {
-               "method": "Basic"   
-            },
-  
-     "cache_control" : "must-revalidate", 
+     "exposed" : true,
 
-     "cors" :                      
+     "authentication" :
+            {
+               "method": "Basic"
+            },
+
+     "cache_control" : "must-revalidate",
+
+     "cors" :
             {
              "enabled" : false
-            }, 
-                     
+            },
+
      "enable_etags" : false,
 
      "force_ssl" : false,
-     
+
      "prevent_xsrf" : false
 }

--- a/app/models/CA_USER_SCHEMA_001.calculationview
+++ b/app/models/CA_USER_SCHEMA_001.calculationview
@@ -10,11 +10,11 @@
         <viewAttribute datatype="VARCHAR" id="SCHEMA_NAME" length="12"/>
       </viewAttributes>
       <calculatedViewAttributes/>
-      <definition> 
- /********* Begin Procedure Script ************/ 
- BEGIN 
- 	 var_out = SELECT DISTINCT SCHEMA_NAME 
- 	 FROM SYS.TABLES; 
+      <definition>
+ /********* Begin Procedure Script ************/
+ BEGIN
+ 	 var_out = SELECT DISTINCT SCHEMA_NAME
+ 	 FROM SYS.TABLES;
 
 END /********* End Procedure Script ************/</definition>
     </calculationView>

--- a/app/models/CA_USER_TABLES_001.calculationview
+++ b/app/models/CA_USER_TABLES_001.calculationview
@@ -19,11 +19,11 @@
       </viewAttributes>
       <calculatedViewAttributes/>
       <localVariable>#p_schema_name</localVariable>
-      <definition> 
- /********* Begin Procedure Script ************/ 
- BEGIN 
- 	 var_out = SELECT   TABLE_NAME 
- 	           FROM     SYS.TABLES 
+      <definition>
+ /********* Begin Procedure Script ************/
+ BEGIN
+ 	 var_out = SELECT   TABLE_NAME
+ 	           FROM     SYS.TABLES
  	           WHERE    SCHEMA_NAME = :p_schema_name
  	           ORDER BY TABLE_NAME;
 

--- a/app/models/CA_USER_TABLE_COLUMNS_001.calculationview
+++ b/app/models/CA_USER_TABLE_COLUMNS_001.calculationview
@@ -30,9 +30,9 @@
       <calculatedViewAttributes/>
       <localVariable>#p_schema_name</localVariable>
       <localVariable>#p_table_name</localVariable>
-      <definition> 
- /********* Begin Procedure Script ************/ 
- BEGIN 
+      <definition>
+ /********* Begin Procedure Script ************/
+ BEGIN
  	 var_out = SELECT COLUMN_NAME, POSITION
  	 , DATA_TYPE_NAME, DATA_TYPE_ID
  	 FROM SYS.TABLE_COLUMNS

--- a/app/services/odxl_user_objects.xsodata
+++ b/app/services/odxl_user_objects.xsodata
@@ -1,26 +1,26 @@
 // To define an XS OData service, you can use the following syntax.
 // In the example below Aggregation, Modification and Association are defined.
 
-service  { 
+service  {
 
     "system-local.public.rbouman.odxl.app.models::CA_USER_SCHEMA_001" as "schemas"
     keys generate local "ID"
-    create forbidden             
-    update forbidden  
+    create forbidden
+    update forbidden
     delete forbidden;
 
     "system-local.public.rbouman.odxl.app.models::CA_USER_TABLES_001" as "TABLES"
     keys generate local "ID"
     parameters via entity "tables"
-    create forbidden             
-    update forbidden  
+    create forbidden
+    update forbidden
     delete forbidden;
 
     "system-local.public.rbouman.odxl.app.models::CA_USER_TABLE_COLUMNS_001" as "COLUMNS"
     keys generate local "ID"
     parameters via entity "columns"
-    create forbidden             
-    update forbidden  
+    create forbidden
+    update forbidden
     delete forbidden;
 
-}  
+}

--- a/app/ui/index.html
+++ b/app/ui/index.html
@@ -21,11 +21,11 @@ limitations under the License.
             body {
                 font-family: sans-serif;
             }
-            
+
             textarea {
                 font-family: monospace;
             }
-            
+
             tr.header td {
                 font-weight: bold;
             }
@@ -71,17 +71,17 @@ limitations under the License.
 	            <tr>
 					<td>OData URL:</td>
 					<td >
-					   <textarea cols="80", rows="5" id="odataUrl">
+					   <textarea cols="80" rows="5" id="odataUrl">
 					   </textarea>
 					</td>
 				</tr>
 	        </table>
 
-            <table> 
+            <table>
                 <tr>
                     <td valign="top">
 			            <div> Download single dataset:</div>
-			            <div> 
+			            <div>
 			                as <a id="downloadCsvLink" target="_blank" download="odxl.csv">.csv File</a>
 			            </div>
 			            <div>
@@ -101,7 +101,7 @@ limitations under the License.
             </table>
 
         </div>
-        
+
         <script type="text/javascript" src="js/common.js"></script>
     </body>
 </html>

--- a/service/.xsaccess
+++ b/service/.xsaccess
@@ -1,21 +1,21 @@
 {
-     "exposed" : true,  
-                  
-     "authentication" :                                            
-            {
-               "method": "Basic"   
-            },
-  
-     "cache_control" : "must-revalidate", 
+     "exposed" : true,
 
-     "cors" :                      
+     "authentication" :
+            {
+               "method": "Basic"
+            },
+
+     "cache_control" : "must-revalidate",
+
+     "cors" :
             {
              "enabled" : false
-            }, 
-                     
+            },
+
      "enable_etags" : false,
 
      "force_ssl" : false,
-     
+
      "prevent_xsrf" : false
 }

--- a/service/config.xsjslib
+++ b/service/config.xsjslib
@@ -16,14 +16,14 @@ limitations under the License.
 (function(exports){
 	/**
 	 * The database interface (db, hdb) to use for database interaction.
-	 * Mainly configurable to enable testing. 
+	 * Mainly configurable to enable testing.
 	 * Users should probably not configure this and let ODXL figure it out.
 	 */
 	//exports.databaseInterface = "db";
 	//exports.databaseInterface = "hdb";
 	/**
 	 * The zip interface (jszip, hdb) to use for workbook generation.
-	 * Mainly configurable to enable testing. 
+	 * Mainly configurable to enable testing.
 	 * Users should probably not configure this and let ODXL figure it out.
 	 */
 	//exports.zipInterface = "jszip.xsjslib";
@@ -38,7 +38,7 @@ limitations under the License.
 		"ods": 	"application/vnd.oasis.opendocument.spreadsheet",
 		"zip":  "application/zip"
 	};
-	
+
 	/**
 	 * Maps content types to handlers.
 	 * The odxl service uses this to load and execute the appropriate output handler to deliver data in the response.

--- a/service/handlers/csvhandler.xsjslib
+++ b/service/handlers/csvhandler.xsjslib
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 (function(exports){
-	
+
 	var csv = $.import("../xsjslib/csv.xsjslib");
 	var params = $.import("../xsjslib/params.xsjslib");
 
@@ -45,7 +45,7 @@ limitations under the License.
 			value: ""
 		}
 	});
-	
+
 	function handleRequest(parameters, contentType, resultset){
 		try {
 			parameters = params.validate();
@@ -61,7 +61,7 @@ limitations under the License.
 			throw e.toString() + " - " + e.linenumber + " " + JSON.stringify(e.stack, "", " ");
 		}
 	}
-	
+
 	exports.handleRequest = handleRequest;
-	
+
 }(this));

--- a/service/handlers/xlsxhandler.xsjslib
+++ b/service/handlers/xlsxhandler.xsjslib
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 (function(exports){
-	
+
 	var xlsx = $.import("../xsjslib/xlsx.xsjslib");
 	var params = $.import("../xsjslib/params.xsjslib");
 	params.define({
 		//specify the name of the sheet where the data appears
-		sheetname: {			
+		sheetname: {
 			type: "VARCHAR",
 			mandatory: false
 		},
@@ -54,13 +54,13 @@ limitations under the License.
 			func: function(){
 				return $.request.queryPath;
 			}
-		}, 
+		},
 		path: {
 			type: "s",
 			func: function(){
 				return $.request.path;
 			}
-		}, 
+		},
 		params: {
 			type: "s",
 			func: function(){
@@ -69,17 +69,17 @@ limitations under the License.
 			}
 		}
 	};
-	
+
 	function handleBatchStart(){
 		var xlsxWorkbook = new xlsx.Workbook();
 		return xlsxWorkbook;
 	}
-	
+
 	function handleBatchEnd(batchContext){
 		var archive = batchContext.pack();
 		return archive;
 	}
-	
+
 	function writeMetaFieldsToWorksheet(parameters, xlsxWorksheet){
 		var wb = xlsxWorksheet.getWorkbook();
 		var xw = xlsxWorksheet.getWriter();
@@ -146,12 +146,12 @@ limitations under the License.
 				xw.closeElement();	//v
 				xw.closeElement();	//c
 			}
-			
+
 			xw.closeElement();	//row
 		}
 		return i+1;
 	}
-		
+
 	function generateWorksheet(xlsxWorkbook, parameters, resultset) {
 		var sheetName = parameters.sheetname || "Sheet";
 		var name = sheetName, num = 0;
@@ -172,8 +172,8 @@ limitations under the License.
 
 		xlsxWorksheet.close();
 		return xlsxWorksheet;
-	}	
-	
+	}
+
 	function handleRequest(parameters, contentType, resultset){
 		try {
 			parameters = params.validate();
@@ -191,10 +191,10 @@ limitations under the License.
 			throw e.toString() + " - " + e.linenumber + " " + JSON.stringify(e.stack, "", " ");
 		}
 	}
-	
+
 	exports.handleBatchStart = handleBatchStart;
 	exports.handleBatchPart = generateWorksheet;
 	exports.handleBatchEnd = handleBatchEnd;
 	exports.handleRequest = handleRequest;
-	
+
 }(this));

--- a/service/xsjslib/csv.xsjslib
+++ b/service/xsjslib/csv.xsjslib
@@ -15,7 +15,7 @@ limitations under the License.
 */
 (function(exports){
 	//https://tools.ietf.org/html/rfc4180
-	
+
 	var error = $.import("error.xsjslib");
 
 	function getChars(string){
@@ -26,7 +26,7 @@ limitations under the License.
 		}
 		return chars;
 	}
-	
+
 	function getJsStringCode(string){
 		if (!string) {
 			return "\"\"";
@@ -34,7 +34,7 @@ limitations under the License.
 		var chars = getChars(string);
 		return "String.fromCharCode(" + chars.join(", ") + ")";
 	}
-	
+
 	function getRegexCode(string){
 		var regexCode = [], hex;
 		var chars = getChars(string);
@@ -44,20 +44,20 @@ limitations under the License.
 			switch (hex.length) {
 				case 1:
 					hex = "0" + hex;
-					//fallthrough
+					/* falls through */
 				case 2:
 					hex = "0" + hex;
-					//fallthrough
+					/* falls through */
 				case 3:
 					hex = "0" + hex;
-					//fallthrough
+					/* falls through */
 			}
 			hex = "\\u" + hex;
 			regexCode.push(hex);
 		}
 		return regexCode.join("");
 	}
-	
+
 	function getHeaderRow(resultset, parameters){
 		var fieldsep = parameters.fieldsep;
 		var rowsep = parameters.rowsep;
@@ -85,10 +85,10 @@ limitations under the License.
 		header = header.join(fieldsep);
 		return header;
 	}
-	
+
 	function createRowWriter(resultset, parameters){
 		var rowWriter = [];
-				
+
 		rowWriter.push("var val, csv = [];");
 
 		var rowsep = parameters.rowsep;
@@ -113,15 +113,15 @@ limitations under the License.
 				reEnc += getRegexCode(fieldsep);
 			}
 			reEnc = "/" + reEnc + "/";
-			rowWriter.push("var enclosedby = " + getJsStringCode(parameters.enclosedby) + ";");			
+			rowWriter.push("var enclosedby = " + getJsStringCode(parameters.enclosedby) + ";");
 			rowWriter.push("var reEnc = " + reEnc + ";");
-			
+
 			var escapedby = parameters.escapedby || enclosedby;
 			rowWriter.push("var escRepl = " + getJsStringCode(escapedby) + " + \"$&\";");
-			
+
 			rowWriter.push("var reEsc = /" + getRegexCode(enclosedby) + "/g;");
 		}
-		
+
 		var metadata = resultset.getColumnMetadata();
 		var i, c, n = metadata.length, columnType, columnName;
 		var isArray, isDate;
@@ -157,11 +157,11 @@ limitations under the License.
 				case 16:	//timestamp
 				case 17:	//seconddate
 					isDate = true;
-					//fallthrough
+					/* falls through */
 				case 51:	//text
 				case 75:	//ST_POINT
 					isArray = true;
-					//fallthrough
+					/* falls through */
 				case 8: 	//char
 				case 9:	 	//varchar
 				case 10:	//nchar
@@ -171,12 +171,12 @@ limitations under the License.
 				case 53:	//shorttext
 				case 54:	//alphanum
 					if (isDate) {
-						rowWriter.push("val = val.toISOString();");							
+						rowWriter.push("val = val.toISOString();");
 					}
 					else
 					if (isArray) {
 						rowWriter.push("val = String.fromCharCode.apply(null, new Uint8Array(val));");
-					}						
+					}
 
 					if (reEnc) {
 						rowWriter.push("if (reEnc.test(val)){");
@@ -192,33 +192,40 @@ limitations under the License.
 			}
 			rowWriter.push("csv.push(val);");
 		}
-		
+
 		rowWriter.push("csv = csv.join(fieldsep);");
 		rowWriter.push("return csv;");
 
 		rowWriter = rowWriter.join("\n");
 		//throw new Error(rowWriter);
+
+
+    /* Turn off JSHint warnings for this statement as it is intended
+       to be a form of eval in order to deal with generated code. */
+    /* jshint ignore:start */
 		rowWriter = new Function("rowIndex", "rowData", rowWriter);
+    /* jshint ignore:end */
+
 		return rowWriter;
 	}
-		
+
 	function writeResultsetAsCsv(resultset, parameters) {
 		var body = [];
 		var rowWriter = createRowWriter(resultset, parameters);
-		
+
 		//write header row
 		if (parameters.header !== "false"){
 			body.push(getHeaderRow(resultset, parameters));
 		}
-		
+
 		//write data rows
 		resultset.iterate(function(rownum, row){
 			body.push(rowWriter.call(null, rownum, row));
 		});
-		
+
 		body = body.join(parameters.rowsep);
 		return body;
 	}
-	
+
 	exports.writeResultsetAsCsv = writeResultsetAsCsv;
 }(this));

--- a/service/xsjslib/error.xsjslib
+++ b/service/xsjslib/error.xsjslib
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 (function(exports){
-	
+
 /*********************************************
-* 
+*
 * 	Error handling
-* 
+*
 ********************************************/
 	function throwError(func, args, message, error){
 		args = null;
@@ -33,7 +33,7 @@ limitations under the License.
 		};
 		throw err;
 	}
-	
+
 	exports.raise = throwError;
-	
+
 }(this));

--- a/service/xsjslib/jszip.xsjslib
+++ b/service/xsjslib/jszip.xsjslib
@@ -1,5 +1,5 @@
 (function(exports){
-  
+
   /*!
 
   JSZip - A Javascript class for generating and reading zip files
@@ -16,7 +16,7 @@
     else if("function"==typeof define&&define.amd)define([],e);
     else{
       var f;
-      "undefined"!=typeof exports?f=exports:"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.JSZip=e()
+      "undefined"!=typeof exports?f=exports:"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.JSZip=e();
     }
   }(function(){
     var define,module,exports;
@@ -28,12 +28,12 @@
                 var a=typeof require=="function"&&require;
                 if(!u&&a)return a(o,!0);
                 if(i)return i(o,!0);
-                throw new Error("Cannot find module '"+o+"'")
+                throw new Error("Cannot find module '"+o+"'");
               }
               var f=n[o]={
                   exports:{}
               };
-              t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+              t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e);},f,f.exports,e,t,n,r);}return n[o].exports;}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s;})({1:[function(_dereq_,module,exports){
   'use strict';
   // private property
   var _keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
@@ -626,7 +626,7 @@
       return Buffer.isBuffer(b);
   };
 
-  }).call(this,(typeof Buffer !== "undefined" ? Buffer : undefined))
+}).call(this,(typeof Buffer !== "undefined" ? Buffer : undefined));
   },{}],12:[function(_dereq_,module,exports){
   'use strict';
   var Uint8ArrayReader = _dereq_('./uint8ArrayReader');
@@ -1001,7 +1001,7 @@
           result.crc32 = file._data.crc32;
 
           if (result.uncompressedSize === 0 || file.dir) {
-              compression = compressions['STORE'];
+              compression = compressions.STORE;
               result.compressedContent = "";
               result.crc32 = 0;
           }
@@ -1018,7 +1018,7 @@
           // have uncompressed data
           content = getBinaryData(file);
           if (!content || content.length === 0 || file.dir) {
-              compression = compressions['STORE'];
+              compression = compressions.STORE;
               content = "";
           }
           result.uncompressedSize = content.length;
@@ -1650,7 +1650,7 @@
       }
   }
 
-  }).call(this,(typeof Buffer !== "undefined" ? Buffer : undefined))
+}).call(this,(typeof Buffer !== "undefined" ? Buffer : undefined));
   },{}],18:[function(_dereq_,module,exports){
   'use strict';
   var DataReader = _dereq_('./dataReader');
@@ -2094,13 +2094,13 @@
   var transform = {};
 
   // string to ?
-  transform["string"] = {
+  transform.string = {
       "string": identity,
       "array": function(input) {
           return stringToArrayLike(input, new Array(input.length));
       },
       "arraybuffer": function(input) {
-          return transform["string"]["uint8array"](input).buffer;
+          return transform.string.uint8array(input).buffer;
       },
       "uint8array": function(input) {
           return stringToArrayLike(input, new Uint8Array(input.length));
@@ -2111,7 +2111,7 @@
   };
 
   // array to ?
-  transform["array"] = {
+  transform.array = {
       "string": arrayLikeToString,
       "array": identity,
       "arraybuffer": function(input) {
@@ -2126,7 +2126,7 @@
   };
 
   // arraybuffer to ?
-  transform["arraybuffer"] = {
+  transform.arraybuffer = {
       "string": function(input) {
           return arrayLikeToString(new Uint8Array(input));
       },
@@ -2143,7 +2143,7 @@
   };
 
   // uint8array to ?
-  transform["uint8array"] = {
+  transform.uint8array = {
       "string": arrayLikeToString,
       "array": function(input) {
           return arrayLikeToArrayLike(input, new Array(input.length));
@@ -2158,13 +2158,13 @@
   };
 
   // nodebuffer to ?
-  transform["nodebuffer"] = {
+  transform.nodebuffer = {
       "string": arrayLikeToString,
       "array": function(input) {
           return arrayLikeToArrayLike(input, new Array(input.length));
       },
       "arraybuffer": function(input) {
-          return transform["nodebuffer"]["uint8array"](input).buffer;
+          return transform.nodebuffer.uint8array(input).buffer;
       },
       "uint8array": function(input) {
           return arrayLikeToArrayLike(input, new Uint8Array(input.length));
@@ -3852,9 +3852,9 @@
   // Small size is preferable.
 
   function adler32(adler, buf, len, pos) {
-    var s1 = (adler & 0xffff) |0
-      , s2 = ((adler >>> 16) & 0xffff) |0
-      , n = 0;
+    var s1 = (adler & 0xffff) |0,
+        s2 = ((adler >>> 16) & 0xffff) |0,
+        n = 0;
 
     while (len !== 0) {
       // Set limit ~ twice less than 5552, to keep
@@ -3953,8 +3953,8 @@
 
 
   function crc32(crc, buf, len, pos) {
-    var t = crcTable
-      , end = pos + len;
+    var t = crcTable,
+        end = pos + len;
 
     crc = crc ^ (-1);
 
@@ -5753,7 +5753,7 @@
                          // but leave for few code modifications
 
     //
-    // Setup limits is not necessary because in js we should not preallocate memory 
+    // Setup limits is not necessary because in js we should not preallocate memory
     // for inflate use constant limit in 65536 bytes
     //
 
@@ -9177,7 +9177,7 @@
 
   module.exports = ZStream;
   },{}]},{},[9])
-  (9)
+  (9);
   });
-  
+
 }(this));

--- a/service/xsjslib/odatafilterparser.xsjslib
+++ b/service/xsjslib/odatafilterparser.xsjslib
@@ -15,8 +15,8 @@ limitations under the License.
 */
 (function(exports){
 
-var Tokenizer = $.import("tokenizer.xsjslib").Tokenizer;	
-	
+var Tokenizer = $.import("tokenizer.xsjslib").Tokenizer;
+
 //file://just-biserver/RedirectedFolders/rbouman/My%20Documents/[MS-ODATA].pdf
 //page 85
 var optypes = {
@@ -341,7 +341,7 @@ ODataFilterParser.prototype = {
     var tokenDefs = this.tokenDefs;
     var tokenizer = this.tokenizer;
     tokenizer.text(text);
-    
+
     tokenizer.each(function(token){
       var tokenDef = tokenDefs[token.type];
       if (!tokenDef) {
@@ -351,12 +351,12 @@ ODataFilterParser.prototype = {
       if (tokenDef.type === optypes.notimplemented) {
         throw new Error("Feature not implemented at token \"" + token.text + " position " + token.at + ".");
       }
-    
+
       token.tokenDef = tokenDef;
-      
+
       prevToken.next = token;
       token.prev = prevToken;
-      
+
 
       token.prevOperator = prevOperator;
       if (tokenDef.type.isOperator) {
@@ -366,7 +366,7 @@ ODataFilterParser.prototype = {
       firstToken.lastToken = token;
       prevToken = token;
     });
-    
+
     var lastRealToken = firstToken.lastToken;
     var lastToken = {
       type: "last",
@@ -396,13 +396,13 @@ ODataFilterParser.prototype = {
   checkOperand: function(operator, operand){
     var operandTokenDef = operand.tokenDef;
     if (operandTokenDef.type !== optypes.operand) {
-      throw "Token is not an operand for \"" + operator.text + "\" at position " + operator.at; 
+      throw "Token is not an operand for \"" + operator.text + "\" at position " + operator.at;
     }
     var operatorTokenDef = operator.tokenDef;
     var operandDataType = operandTokenDef.dataType;
     var operatorOperandDataType = operatorTokenDef.operandDataType;
     if (operandDataType && operatorOperandDataType && operandDataType !== operatorOperandDataType) {
-      throw "Datatype mismatch - operator \"" + operator.text + "\" at position " + operator.at + " requires operand with datatype " + operatorOperandDataType + "; operand \"" +  operand.text + "\" has datatype " + operandDataType; 
+      throw "Datatype mismatch - operator \"" + operator.text + "\" at position " + operator.at + " requires operand with datatype " + operatorOperandDataType + "; operand \"" +  operand.text + "\" has datatype " + operandDataType;
     }
   },
   checkFuncArgs: function(funcToken){
@@ -415,7 +415,7 @@ ODataFilterParser.prototype = {
     }
     args.push(operand);
     funcToken.args = args;
-    
+
     var argDefs = funcToken.tokenDef.args, argDef, arg, argDefDataType, argDataType;
     var i, n = argDefs.length, m = args.length;
     if (m > n) {
@@ -426,7 +426,7 @@ ODataFilterParser.prototype = {
       if (i < m) {
         arg = args[i];
       }
-      else 
+      else
       if (argDef.optional !== true) {
         throw "Argument " + i + " for function " + funcToken.funcName + " at " +  funcToken.at + " is missing.";
       }
@@ -453,14 +453,14 @@ ODataFilterParser.prototype = {
   },
   parse: function(text){
     var firstToken = this.tokenize(text);
-    
+
     var prevOperator = firstToken;
     var token = firstToken;
     var tokenDef, reduced;
 
     var rightDataType;
     var leftDataType;
-    
+
     scan: do {
       token = token.next;
       if (!token) {
@@ -526,7 +526,7 @@ ODataFilterParser.prototype = {
         prevOperator = token;
       }
     } while (true);
-    
+
     var parseTree = this.cleanUpParseTreeNode(prevOperator.leftOperand);
     return parseTree;
   }

--- a/service/xsjslib/params.xsjslib
+++ b/service/xsjslib/params.xsjslib
@@ -16,16 +16,16 @@ limitations under the License.
 (function(exports){
 
 	var err = $.import("error.xsjslib");
-    /** 
+    /**
 	* Defines the url query string parameters expected by the service.
-	* 
+	*
 	* The keys in this object are the internal parameter names.
-	* These correspond to the "name" part of the name/value parts 
+	* These correspond to the "name" part of the name/value parts
 	* that make up the "query" part of the url.
-	* 
+	*
 	* Internal parameter names are always UPPER CASE;
 	* Parameter names in te url query string are always lower case.
-	* 
+	*
 	* The values mapped to the keys are parameterDef objects.
 	* ParameterDef objects have these properties:
 	* - type: database data type. Used to validate the value
@@ -33,7 +33,7 @@ limitations under the License.
 	* - minvalue (optional): minimum allowed value
 	* - maxvalue (optional): maximum allowed value
 	* - method (optional): the HTTP method(s) to which this parameter applies. If not specified, the parameter applies to all methods. If specified, it can be either a string (comma separated list of HTTP methods), or an array (containing each method as a string element)
-	* 
+	*
 	* @var parameterDefs
 	*/
 	var parameterDefs = {};
@@ -44,7 +44,7 @@ limitations under the License.
 		}
 		return method;
 	}
-	
+
 	function getDefaultParameters(parameters) {
 		if (parameters === undefined) {
 			parameters = $.request.parameters;
@@ -53,7 +53,7 @@ limitations under the License.
 			var name, value, p = [];
 			if (typeof parameters === "string") {
 				parameters = parameters.split("&");
-				var i, n = parameters.length, paramObject, paramsObject = {}; 
+				var i, n = parameters.length, paramObject, paramsObject = {};
 				for (i = 0; i < n; i++) {
 					paramObject = parameters[i];
 					paramObject = paramObject.split("=");
@@ -97,7 +97,7 @@ limitations under the License.
 					}
 				}
 				break;
-			case 2: 
+			case 2:
 				parameterDefs[name] = parameterDef;
 				break;
 			default:
@@ -111,23 +111,23 @@ limitations under the License.
 				}
 		}
 	}
-	
+
 	/**
-	*	This is a helper for validateParameters(). 
-	* 
+	*	This is a helper for validateParameters().
+	*
 	*   This checks whether the parameter with the specified name applies to the specified HTTP method.
-	*   
+	*
 	*   @function isParameterApplicableForMethod
 	*   @param parameterName {string} Name of the parameter definition to examine
 	*   @param method {string} HTTP method to search for
 	*/
 	function isParameterApplicableForMethod(parameterName, method){
 		method = getDefaultMethod(method);
-		
+
 		var parameterDef = parameterDefs[parameterName];
 		var parameterDefMethod = parameterDef.methods;
-		
-		
+
+
 		if (parameterDefMethod === undefined) {
 			//parameterDef does not specify any particular method;
 			//this means it applies to all methods
@@ -146,20 +146,20 @@ limitations under the License.
 		}
 		else {
 			err.raise(
-				"isParameterApplicableForMethod", 
+				"isParameterApplicableForMethod",
 				arguments,
 				"Method property of parameter definition " + parameterName + " must be either a string or an array of strings."
 			);
 		}
-		
+
 		//check each method
 		var i, n = parameterDefMethods.length;
 		for (i = 0; i < n; i++) {
 			parameterDefMethod = parameterDefMethods[i];
-			
+
 			if (typeof parameterDefMethod !== "string") {
 				err.raise(
-					"isParameterApplicableForMethod", 
+					"isParameterApplicableForMethod",
 					arguments,
 					"Method property of parameter definition " + parameterName + " must be either a string or an array of strings."
 				);
@@ -169,14 +169,14 @@ limitations under the License.
 				return true;
 			}
 		}
-		
+
 		//no matching method.
 		return false;
 	}
 	/**
-	*	This is a helper for validateParamters(). 
-	* 
-	*	Validates a parameter from the query part of the url  
+	*	This is a helper for validateParamters().
+	*
+	*	Validates a parameter from the query part of the url
 	*	against its corresponding parameter definition
 	*
 	*	If the parameter is found to be invalid, and error is thrown.
@@ -220,7 +220,7 @@ limitations under the License.
 			err.raise(
 				"validateParameter",
 				arguments,
-			    "Value " + parameterValue + " of parameter " + parameterName + 
+			    "Value " + parameterValue + " of parameter " + parameterName +
 				" is smaller than the minimum value " + parameterDef.minvalue
 			);
 		}
@@ -228,7 +228,7 @@ limitations under the License.
 			err.raise(
 				"validateParameter",
 				arguments,
-				"Value " + parameterValue + " of parameter " + parameterName + 
+				"Value " + parameterValue + " of parameter " + parameterName +
 				" is larger than the maximum value " + parameterDef.maxvalue
 			);
 		}
@@ -250,13 +250,13 @@ limitations under the License.
 		}
 		return parameterValue;
 	}
-	
+
 	/**
-	*	Function to validate url query string parameters. 
+	*	Function to validate url query string parameters.
 	*	If validation succeeds, this returns an object representing the canonical parameters.
 	*	Any service functionality that needs to access a paramter, should use that object
 	*	rather than accessing $.request.parameters directly.
-	* 
+	*
 	*	@function validateParameters
 	*	@param the HTTP method
 	*	@return {object} An object that maps canonical (upper case) parameternames to their validated typed value
@@ -277,16 +277,16 @@ limitations under the License.
 		}
 		return parameterValues;
 	}
-	
+
 	function getParameterDefs(){
 		var string = JSON.stringify(parameterDefs);
 		var obj = JSON.parse(string);
 		return obj;
 	}
-	
+
 	exports.define = defineParameter;
 	exports.isDefined = isParameterApplicableForMethod;
 	exports.validate = validateParameters;
 	exports.getDefs = getParameterDefs;
-	
+
 }(this));

--- a/service/xsjslib/querybuilder.xsjslib
+++ b/service/xsjslib/querybuilder.xsjslib
@@ -14,25 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 (function(exports){
-	
+
 	function buildQuerySelectClause(req, parameters, query){
 		query.push("SELECT");
 
-		var select = parameters["$select"];
+		var select = parameters.$select;
 		if (select) {
 			select = select.split(",");
 			var i, n = select.length;
 			for (i = 0; i < n; i++) {
 				select[i] = sql.checkIdentifier(select[i], true);
 			}
-			select = parameters["$select"];
+			select = parameters.$select;
 		}
 		else {
 			select = "*";
 		}
 		query.push(select);
 	}
-	
+
 	function buildQueryFromClause(req, parameters, query){
 		query.push("FROM");
 		var tableName = req.tableName;
@@ -48,11 +48,11 @@ limitations under the License.
 		}
 		query.push(stmt);
 	}
-	
+
 	function odataFilterPrecedenceParser(filter){
 		var tokenizer = new tokenizer.Tokenizer();
 	}
-	
+
 	function translateFilterParseTreeToSql(node){
 		var str = "";
 		switch (node.type) {
@@ -102,7 +102,7 @@ limitations under the License.
 					  "le": "<=",
 					  "and": "AND",
 					  "or": "OR",
-					}
+					};
 					left = translateFilterParseTreeToSql(left);
 					right = translateFilterParseTreeToSql(right);
 					if (node.text === "mod") {
@@ -129,10 +129,10 @@ limitations under the License.
 				var needle = translateFilterParseTreeToSql(node.args[1]);
 				switch (node.funcName) {
 					case "endswith":
-						str = "RIGHT(" + haystack + ", LENGTH(" + needle + ")) = " + needle; 
+						str = "RIGHT(" + haystack + ", LENGTH(" + needle + ")) = " + needle;
 						break;
 					case "startswith":
-						str = "LEFT(" + haystack + ", LENGTH(" + needle + ")) = " + needle; 
+						str = "LEFT(" + haystack + ", LENGTH(" + needle + ")) = " + needle;
 						break;
 					default:
 						httpStatus = $.net.http.INTERNAL_SERVER_ERROR;
@@ -237,28 +237,28 @@ limitations under the License.
 		}
 		return str;
 	}
-		
+
 	function buildQueryWhereClause(req, parameters, query){
-		var filter = parameters["$filter"];
+		var filter = parameters.$filter;
 		if (!filter) {
 			return;
 		}
-		
+
 		var odatafilterparser = $.import("odatafilterparser.xsjslib");
 		var parser = new odatafilterparser.ODataFilterParser();
-		
+
 		query.push("WHERE");
 
 		var parseTree = parser.parse(filter);
 		query.push(translateFilterParseTreeToSql(parseTree));
 	}
-	
+
 	function buildQueryOrderByClause(req, parameters, query){
-		var orderby = parameters["$orderby"];
+		var orderby = parameters.$orderby;
 		if (!orderby) {
 			return;
 		}
-		orderby = orderby.split(",")
+		orderby = orderby.split(",");
 		var i, n = orderby.length;
 		for (i = 0; i < n; i++) {
 			if (!/^\s*(\"[^\"]+\"|[_A-Z][A-Z0-9_#$]*)(\s+(asc|desc)\s*)?$/.test(orderby[i])) {
@@ -266,12 +266,12 @@ limitations under the License.
 			}
 		}
 		query.push("ORDER BY");
-		query.push(parameters["$orderby"]);
+		query.push(parameters.$orderby);
 	}
-	
+
 	function buildQueryLimitClause(req, parameters, query) {
-		var top = parameters["$top"];
-		var skip = parameters["$skip"];
+		var top = parameters.$top;
+		var skip = parameters.$skip;
 		if (!top && !skip) {
 			return;
 		}
@@ -286,7 +286,7 @@ limitations under the License.
 		query.push("OFFSET");
 		query.push(skip);
 	}
-	
+
 	function buildQuery(req, parameters){
 		var query = [];
 

--- a/service/xsjslib/sql.xsjslib
+++ b/service/xsjslib/sql.xsjslib
@@ -16,7 +16,7 @@ limitations under the License.
 (function(exports){
 
 	var error = $.import("error.xsjslib");
-	
+
 	var dbInterface = getDefaultDatabaseInterface();
 	function getDefaultDatabaseInterface(){
 		if ($.hdb) {
@@ -31,7 +31,7 @@ limitations under the License.
 		}
 		return null;
 	}
-	
+
 	function setDatabaseInterface(dbi){
 		var interfaces = {
 			"hdb": true,
@@ -45,28 +45,28 @@ limitations under the License.
 		}
 		dbInterface = dbi;
 	}
-	
+
 	function getDatabaseInterface(dbi){
 		if (dbi === undefined){
 			dbi = dbInterface;
 		}
 		return $[dbi];
 	}
-	
+
 	var connection;
 	/**
 	*	Opens the connection and makes sure autocommit is disabled.
-	*	We require this becuase typically our interaction with the 
+	*	We require this becuase typically our interaction with the
 	*	db spans multiple statements
-	*	
+	*
 	*	@function openConnection
 	*/
 	function openConnection(){
 		var dbi = getDatabaseInterface(dbi);
-		connection = dbi.getConnection();  
+		connection = dbi.getConnection();
 		connection.setAutoCommit(false);
 	}
-	
+
 	function rollbackTransaction(){
 		if (connection) {
 			connection.rollback();
@@ -89,7 +89,7 @@ limitations under the License.
 	}
 	/**
 	*	Closes the connection
-	*	
+	*
 	*	@function closeConnection
 	*/
 	function closeConnection(){
@@ -100,7 +100,7 @@ limitations under the License.
 		connection = undefined;
 		return true;
 	}
-	
+
 	function makeObjectName(namesObject){
 		var fullName, contextName, packageName;
 		switch (typeof namesObject) {
@@ -111,22 +111,22 @@ limitations under the License.
 				break;
 			case "object":
 				break;
-			default: 
+			default:
 				error.raise(
-					"makeObjectName", 
+					"makeObjectName",
 					arguments,
 					"Invalid name object."
 				);
 		}
 		fullName = namesObject.objectName;
-		
+
 		contextName = namesObject.contextName;
 		if (contextName) {
 			fullName = contextName + "." + fullName;
 		}
 
 		packageName = namesObject.packageName;
-		
+
 		if (namesObject.subPackageName) {
 			packageName += "." + namesObject.subPackageName;
 		}
@@ -135,7 +135,7 @@ limitations under the License.
 		fullName = "\"" + fullName + "\"";
 		return fullName;
 	}
-	
+
 	/**
 	*	Create a fully qualified table name from the names in the nameObject parameter.
 	*	The namesObject parameter has the following keys:
@@ -147,9 +147,9 @@ limitations under the License.
 	*
 	*	All these items, except the tableName, will be defaulted with defaults if not specified.
 	*
-	*	Alternatively, you can also pass a single string representing the unqalified tablename. 
+	*	Alternatively, you can also pass a single string representing the unqalified tablename.
 	*	In that case, defaults will be used for all other name parts.
-	* 
+	*
 	*	@function makeTableName
 	*	@param {object|string} namesObject Either a bag of different types of names that together make up a fully qualified table name, or a string representing a plain unqualified table name.
 	*	@return {string} A single string that represents a fully qualified table name.
@@ -159,15 +159,15 @@ limitations under the License.
 
 		if (typeof namesObject === "string"){
 			namesObject = {
-				objectName: namesObject	
+				objectName: namesObject
 			};
-		}		
-		
+		}
+
 		fullName = makeObjectName(namesObject);
 
 		schemaName = namesObject.schemaName;
 		schemaName = "\"" + schemaName + "\"";
-			
+
 		fullName = schemaName + "." + fullName;
 		return fullName;
 	}
@@ -177,22 +177,22 @@ limitations under the License.
 
 		if (typeof namesObject === "string"){
 			namesObject = {
-				objectName: namesObject	
+				objectName: namesObject
 			};
-		}		
+		}
 		fullName = makeObjectName(namesObject);
 		return fullName;
 	}
-	
+
 	function createCalcViewPlaceholder(name, value) {
 		name = name.replace(/'/g, "''");
 		value = String(value).replace(/'/g, "''");
 		return "'PLACEHOLDER' = ('$$" + name + "$$', '" + value + "')";
 	}
-	
+
 	function createCalcViewPlaceholders(parameters) {
 		var placeHolders = [];
-		var name, calcViewPlaceHolder, value; 
+		var name, calcViewPlaceHolder, value;
 		for (name in parameters) {
 			if (parameters.hasOwnProperty(name)) {
 				value = parameters[name];
@@ -200,9 +200,9 @@ limitations under the License.
 				placeHolders.push(calcViewPlaceHolder);
 			}
 		}
-		return "(" + placeHolders.join(", ") + ")"; 
+		return "(" + placeHolders.join(", ") + ")";
 	}
-	
+
 	var DBResultSet;
 	(DBResultSet = function(resultset){
 		this.resultset = resultset;
@@ -264,7 +264,7 @@ limitations under the License.
 						extractor.func = resultset.getDecimal;
 						break;
 					case 51:	//TEXT
-					case 52:	//SHORTTEXT	
+					case 52:	//SHORTTEXT
 					case 55:	//ALPHANUM
 						extractor.func = resultset.getText;
 						break;
@@ -272,6 +272,7 @@ limitations under the License.
 						extractor.func = resultset.getSecondDate;
 						break;
 					case 45:	//TABLE
+            /* falls through */
 					default:
 						error.raise("iterate", null, "Don't know which extractor to use for data type: " + metadata.getDataTypeName(i));
 				}
@@ -302,14 +303,14 @@ limitations under the License.
 					precision: metadata.getPrecision(i),
 					scale: metadata.getScale(i),
 					tableName: metadata.getTableName(i),
-					isNullable: true 
+					isNullable: true
 				};
 				ret.push(col);
 			}
 			return ret;
 		}
 	};
-	
+
 	var HDBResultSet;
 	(HDBResultSet = function(resultset){
 		this.resultset = resultset;
@@ -326,23 +327,23 @@ limitations under the License.
 			return this.resultset.metadata.columns;
 		}
 	};
-	
+
 	function hdbQuery(sql, parameters){
 		var connection = getConnection();
 		var args = [sql];
-		
+
 		if (parameters) {
 			var i, n = parameters.length;
 			for (i = 0; i < n; i++) {
 				args.push(parameters[i].value);
 			}
 		}
-		
+
 		var resultset = connection.executeQuery.apply(connection, args);
 		var hdbResultSet = new HDBResultSet(resultset);
 		return hdbResultSet;
 	}
-	
+
 	function dbQuery(sql, parameters){
 		var connection = getConnection();
 		var statement = connection.prepareStatement(sql);
@@ -408,12 +409,13 @@ limitations under the License.
 						statement.setBlob(i, parameter.value);
 						break;
 					case 51:	//TEXT
-					case 52:	//SHORTTEXT	
+					case 52:	//SHORTTEXT
 					case 55:	//ALPHANUM
 						statement.setText(i, parameter.value);
 						break;
 					case 62:	//SECONDDATE
 					case 45:	//TABLE
+            /* falls through */
 					default:
 						error.raise("iterate", null, "Don't know which extractor to use for data type: " + metadata.getDataTypeName(i));
 				}
@@ -423,7 +425,7 @@ limitations under the License.
 		var dbResultset = new DBResultSet(resultset);
 		return dbResultset;
 	}
-	
+
 	function executeQuery(sql, parameters){
 		var interfaces = {
 			"db": dbQuery,
@@ -446,12 +448,12 @@ limitations under the License.
 					tableName: nameObject
 				};
 			}
-			
-			var tableName = "\"_SYS_BIC\"." + 
-			                "\"" + 
-							nameObject.packageName + "."  + 
-							nameObject.subPackageName + "/" + 
-							nameObject.tableName + 
+
+			var tableName = "\"_SYS_BIC\"." +
+			                "\"" +
+							nameObject.packageName + "."  +
+							nameObject.subPackageName + "/" +
+							nameObject.tableName +
 			                "\""
 			;
 			sql = "SELECT * FROM " + tableName;
@@ -474,12 +476,12 @@ limitations under the License.
 	*	@return an object with column values as both keys and values.
 	*/
 	function getRowList(namesObject){
-		var list = {}; 
+		var list = {};
 		var fullTableName = makeTableName(namesObject);
 		var columnName = namesObject.columnName;
 		var query = " SELECT DISTINCT " + columnName +
 					" FROM   " + fullTableName
-		;  
+		;
 		var value, rs = executeQuery(query);
 		rs.iterate(function(rownum, row){
 			value = row[columnName];
@@ -487,13 +489,13 @@ limitations under the License.
 		});
 		return list;
 	}
-	
+
 	function getColumnAssignment(columnAssignments, columnName){
 		var columnAssignment = columnAssignments[columnName];
 		switch (typeof columnAssignment) {
 			case "undefined":
 				columnAssignment = null;
-				//fallthrough
+				/* falls through */
 			case "object":
 				if (columnAssignment === null) {
 					columnAssignment = {expression: "NULL"};
@@ -505,8 +507,8 @@ limitations under the License.
 		return columnAssignment;
 	}
 	/**
-	*	Create the SQL for a INSERT INTO <table>(<columns...>) VALUES (<expressions and parameters>) statement  
-	* 
+	*	Create the SQL for a INSERT INTO <table>(<columns...>) VALUES (<expressions and parameters>) statement
+	*
 	*	@function createInsertValuesStatement
 	*   @param {object|string} namesObject
 	*   @param {object|string} columnAssignments
@@ -525,7 +527,7 @@ limitations under the License.
 					if (columnAssignment.expression !== undefined) {
 						parameters.push(columnAssignment.expression);
 					}
-					else 
+					else
 					if (columnAssignment.value !== undefined) {
 						parameters.push("?");
 					}
@@ -534,8 +536,8 @@ limitations under the License.
 
 			columns 	= "(" + columns.join(",") + ")";
 			parameters	= "(" + parameters.join(",") + ")";
-			
-			var sql = 	"insert "			+ 
+
+			var sql = 	"insert "			+
 						"into " + tableName	+
 			 			columns				+
 			 			"values" 			+
@@ -548,18 +550,18 @@ limitations under the License.
 		}
 		return null;
 	}
-	
+
 	/*
-	*	A place to cache procedures. This is used by callProcedure() 
-	*	and should not be accessed directly.	
-	* 
+	*	A place to cache procedures. This is used by callProcedure()
+	*	and should not be accessed directly.
+	*
 	*	@var procedureCache
 	*/
 	var procedureCache = {};
-	
+
 	/**
 	*	A function to call a database stored procedure.
-	*	
+	*
 	*	@function callProcedure
 	*	@param namesObject {object |string} name of the procedure.
 	*	@param parametersObject {object} Name/value pairs to use as procedure parameters.
@@ -574,20 +576,20 @@ limitations under the License.
 			procedureCache[schemaName] = schema;
 		}
 		var procName = makeProcedureName(namesObject);
-		
+
 		var proc = schema[procName];
 		var connection = getConnection();
 		if (!proc) {
 			proc = connection.loadProcedure(schemaName, procName);
 			schema[procName] = proc;
 		}
-		
+
 		var result;
 		result = proc.call(connection, parametersObject);
-		
+
 		return result;
 	}
-	
+
 	//https://help.sap.com/saphelp_hanaplatform/helpdata/en/20/9f5020751910148fd8fe88aa4d79d9/content.htm
 	function checkIdentifier(identifier, quote){
 		var match = /^\"[^\"]+\"|[_A-Za-z][A-Za-z0-9_#$]*$/.exec(identifier);
@@ -601,11 +603,11 @@ limitations under the License.
 		}
 		return identifier;
 	}
-	
+
 	/**
 	*	Insert one row of values and/or expressions into a table.
 	*
-	*	@function executeInsertValues 
+	*	@function executeInsertValues
 	*	@param namesObject {object | string} Table name or name object.
 	*	@param columnAssignments {object} Object mapping column names to values or SQL expressions
 	*	@return {int} the number of rows inserted. Should be 1.
@@ -617,7 +619,7 @@ limitations under the License.
 			for (columnName in columnAssignments) {
 				if (columnAssignments.hasOwnProperty(columnName)){
 					columnAssignment = getColumnAssignment(columnAssignments, columnName);
-					
+
 					if (columnAssignment.value !== undefined) {
 						values.push(columnAssignment.value);
 					}
@@ -637,7 +639,7 @@ limitations under the License.
 	exports.setDatabaseInterface = setDatabaseInterface;
 	exports.getDefaultDatabaseInterface = getDefaultDatabaseInterface;
 	exports.openConnection = openConnection;
-	exports.getConnection = getConnection;	
+	exports.getConnection = getConnection;
 	exports.rollbackTransaction = rollbackTransaction;
 	exports.commitTransaction = commitTransaction;
 	exports.closeConnection = closeConnection;
@@ -650,5 +652,5 @@ limitations under the License.
 	exports.makeTableName = makeTableName;
 	exports.checkIdentifier = checkIdentifier;
 	exports.createCalcViewPlaceholders = createCalcViewPlaceholders;
-	
+
 }(this));

--- a/service/xsjslib/tokenizer.xsjslib
+++ b/service/xsjslib/tokenizer.xsjslib
@@ -300,7 +300,7 @@ Tokenizer.prototype = {
                     exclude = {};
                     for (var i = 0, n = config.length, v; i < n; i++) {
                         v = config[i];
-                        if (typeof(v) !== "string") throw "Invalid argument."
+                        if (typeof(v) !== "string") throw "Invalid argument.";
                         exclude[v] = true;
                     }
                 }
@@ -310,7 +310,7 @@ Tokenizer.prototype = {
                 exclude = null;
                 break;
             default:
-                throw "Invalid argument."
+                throw "Invalid argument.";
         }
         this._exclude = exclude;
     }
@@ -318,4 +318,4 @@ Tokenizer.prototype = {
 
 exports.Tokenizer = Tokenizer;
 
-}(this))
+}(this));

--- a/service/xsjslib/xlsx.xsjslib
+++ b/service/xsjslib/xlsx.xsjslib
@@ -78,7 +78,7 @@ XlsxWorksheet.prototype = {
 	close: function(){
 		var xw = this.getWriter();
 		xw.closeElement();	//sheetData
-		xw.closeElement();	//worksheet			
+		xw.closeElement();	//worksheet
 	},
 	writeResultset: function(resultset, xlsxWorksheet, rowIndex) {
 		var xw = this.getWriter();
@@ -87,10 +87,10 @@ XlsxWorksheet.prototype = {
 		if (rowIndex === undefined) {
 			rowIndex = 1;
 		}
-		
+
 		var i, columnMetadata,
-			columnsMetadata = resultset.getColumnMetadata(), 
-			n = columnsMetadata.length, 
+			columnsMetadata = resultset.getColumnMetadata(),
+			n = columnsMetadata.length,
 			columnLetter, columnType, columnName,
 			excelType, excelStyle, sharedStringIndex
 		;
@@ -99,27 +99,27 @@ XlsxWorksheet.prototype = {
 		xw.writeAttribute("r", rowIndex);
 
 		var rowWriter = [];
-		rowWriter.push("var wb = ws.getWorkbook(), ns = wb.XLSX_NS_MAIN, xw = ws.getWriter(), v;");		
+		rowWriter.push("var wb = ws.getWorkbook(), ns = wb.XLSX_NS_MAIN, xw = ws.getWriter(), v;");
 		rowWriter.push("xw.openElement(\"row\", ns);");
 		rowWriter.push("xw.writeAttribute(\"r\", rowIndex);");
-		
+
 		for (i = 0; i < n; i++) {
 			columnLetter = xlsxIntToColumnLetter(i + 1);
 			columnMetadata = columnsMetadata[i];
 			columnName = columnMetadata.name;
 			columnType = columnMetadata.type;
-				
+
 			xw.openElement("c", XLSX_NS_MAIN);
 			xw.writeAttributes({
 				r: columnLetter + rowIndex,
 				s: 0,
 				t: "s",
 			});
-			
+
 			rowWriter.push("");
 			rowWriter.push("v = resultset[\"" + columnName + "\"];");
 			rowWriter.push("if (v !== null) {");
-			rowWriter.push("  xw.openElement(\"c\", ns);");			
+			rowWriter.push("  xw.openElement(\"c\", ns);");
 
 			excelStyle = null;
 			switch (columnType) {
@@ -132,7 +132,7 @@ XlsxWorksheet.prototype = {
 				case 7: 	//double
 				case 47: 	//smalldecimal
 					//excel number type
-					excelType = "n";	
+					excelType = "n";
 					break;
 				case 12:	//binary
 				case 13:	//varbinary
@@ -140,7 +140,7 @@ XlsxWorksheet.prototype = {
 				case 51:	//text
 				case 75:	//ST_POINT
 					rowWriter.push("  v = String.fromCharCode.apply(null, new Uint16Array(v));");
-					//fallthrough
+					/* falls through */
 				case 8: 	//char
 				case 9:	 	//varchar
 				case 10:	//nchar
@@ -150,7 +150,7 @@ XlsxWorksheet.prototype = {
 				case 53:	//shorttext
 				case 54:	//alphanum
 					//excel shared string type.
-					excelType = "s";	
+					excelType = "s";
 					rowWriter.push("  v = wb.getSharedStringIndex(v);");
 					break;
 				case 14:	//date
@@ -170,36 +170,41 @@ XlsxWorksheet.prototype = {
 			rowWriter.push("  xw.writeAttributes({");
 			rowWriter.push("    r: \"" + columnLetter + "\" + rowIndex,");
 			if (excelStyle) {
-				rowWriter.push("    s: \"" + excelStyle + "\",");			
+				rowWriter.push("    s: \"" + excelStyle + "\",");
 			}
-			rowWriter.push("    t: \"" + excelType + "\"");			
-			rowWriter.push("  });");			
-			
-			xw.openElement("v", XLSX_NS_MAIN);			
-			rowWriter.push("  xw.openElement(\"v\", ns);");			
-			
+			rowWriter.push("    t: \"" + excelType + "\"");
+			rowWriter.push("  });");
+
+			xw.openElement("v", XLSX_NS_MAIN);
+			rowWriter.push("  xw.openElement(\"v\", ns);");
+
 			sharedStringIndex = wb.getSharedStringIndex(columnMetadata.label || columnName);
 			xw.writeText(sharedStringIndex);
-			rowWriter.push("  xw.writeText(v);");			
-			
+			rowWriter.push("  xw.writeText(v);");
+
 			xw.closeElement(); //v
 			rowWriter.push("  xw.closeElement(); //v");
 			xw.closeElement(); //c
 			rowWriter.push("  xw.closeElement(); //c");
 
-			rowWriter.push("} //if (v !== null)");				
-			
+			rowWriter.push("} //if (v !== null)");
+
 		}
 		xw.closeElement(); //row
 		rowWriter.push("xw.closeElement(); //row");	//r
-		
+
 		rowWriter = rowWriter.join("\n");
+
+    /* Turn off JSHint warnings for this statement as it is intended
+       to be a form of eval in order to deal with generated code. */
+    /* jshint ignore:start */
 		rowWriter = new Function("ws", "resultset", "rowIndex", rowWriter);
+    /* jshint ignore:end */
 
 		resultset.iterate(function(rownum, row){
 			rowWriter.call(null, xlsxWorksheet, row, rowIndex + 1 + rownum);
 		});
-	}		
+	}
 };
 
 var XlsxWorkbook;
@@ -326,7 +331,7 @@ var XlsxWorkbook;
 			"ContentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
 		});
 		xw.closeElement();
-		
+
 		//worksheets
 		this.eachSheet(function(sheet, i){
 			xw.openElement("Override", this.XLSX_NS_CONTENT_TYPES);
@@ -336,7 +341,7 @@ var XlsxWorkbook;
 			});
 			xw.closeElement();
 		});
-		
+
 		//styles.xml
 		xw.openElement("Override", XLSX_NS_CONTENT_TYPES);
 		xw.writeAttributes({
@@ -344,7 +349,7 @@ var XlsxWorkbook;
 			"ContentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"
 		});
 		xw.closeElement();
-		
+
 		//shared strings
 		if (this.hasSharedStrings()) {
 			xw.openElement("Override", XLSX_NS_CONTENT_TYPES);
@@ -354,10 +359,10 @@ var XlsxWorkbook;
 			});
 			xw.closeElement();
 		}
-		
+
 		//Types
 		xw.closeElement();
-		
+
 		return xw.asXml();
 	},
 	generateWorkbookXml: function(){
@@ -368,7 +373,7 @@ var XlsxWorkbook;
 		xw.openElement("workbook");
 		xw.declareNs("", ns);
 		xw.declareNs("ns1", this.XLSX_NS_RELS);
-		
+
 		xw.openElement("sheets", ns);
 		this.eachSheet(function(sheet, i){
 			var id = i + 1;
@@ -401,14 +406,14 @@ var XlsxWorkbook;
 		xw.closeElement();
 
 		xw.closeElement();
-		
+
 		//fills
 		xw.openElement("fills", ns);
 		xw.writeAttribute("count", 1);
 
 		xw.openElement("fill", ns);
 		xw.closeElement();
-		
+
 		xw.closeElement();
 
 		//borders
@@ -423,17 +428,17 @@ var XlsxWorkbook;
 		//cellStyleXfs
 		xw.openElement("cellStyleXfs", ns);
 		xw.writeAttribute("count", 1);
-		
+
 		xw.openElement("xf", ns);
 		xw.writeAttribute("numFmtId", 0);
 		xw.closeElement();
-		
+
 		xw.closeElement();
 
 		//cellXfs
 		xw.openElement("cellXfs", ns);
 		xw.writeAttribute("count", 1);
-		
+
 		xw.openElement("xf", ns);
 		xw.writeAttribute("numFmtId", 0);
 		xw.closeElement();
@@ -441,9 +446,9 @@ var XlsxWorkbook;
 		xw.openElement("xf", ns);
 		xw.writeAttribute("numFmtId", 14);
 		xw.closeElement();
-		
+
 		xw.closeElement();
-		
+
 		//cellStyles
 		//xw.openElement("cellStyles", ns);
 		//xw.writeAttribute("count", 0);
@@ -453,7 +458,7 @@ var XlsxWorkbook;
 		xw.openElement("dxfs", ns);
 		xw.writeAttribute("count", 0);
 		xw.closeElement();
-		
+
 		//tableStyles
 		xw.openElement("tableStyles", ns);
 		xw.writeAttribute("count", 0);
@@ -482,7 +487,7 @@ var XlsxWorkbook;
 			});
 			xw.closeElement();	//Relationship
 		});
-		
+
 		//styles.xml
 		xw.openElement("Relationship", ns);
 		id += 1;
@@ -492,7 +497,7 @@ var XlsxWorkbook;
 			Target: "styles.xml"
 		});
 		xw.closeElement();	//Relationship
-		
+
 		//sharedStrings.xml
 		if (this.hasSharedStrings()) {
 			xw.openElement("Relationship", ns);
@@ -504,7 +509,7 @@ var XlsxWorkbook;
 			});
 			xw.closeElement();	//Relationship
 		}
-		
+
 		xw.closeElement();	//Relationships
 		return xw.asXml();
 	},
@@ -544,7 +549,7 @@ var XlsxWorkbook;
 			xw.closeElement();	//t
 			xw.closeElement();	//si
 		});
-		
+
 		xw.closeElement();	//sst
 		return xw.asXml();
 	},
@@ -572,7 +577,7 @@ var XlsxWorkbook;
 	},
 	pack: function(){
 		var contentPackage = this.getContentPackage();
-		
+
 		this.eachSheet(function(sheet, i){
 			this.packSheet(sheet);
 		});
@@ -583,14 +588,14 @@ var XlsxWorkbook;
 		contentPackage["xl/workbook.xml"] = this.generateWorkbookXml();
 		contentPackage["xl/styles.xml"] = this.generateStylesXml();
 
-		if (this.hasSharedStrings()){ 
+		if (this.hasSharedStrings()){
 			contentPackage["xl/sharedStrings.xml"] = this.generateSharedStringsXml();
 		}
 		var zip = this.createArchiveForContentPackage();
 		return zip;
 	}
 };
-	
+
 exports.Workbook = XlsxWorkbook;
 
 }(this));

--- a/service/xsjslib/xmlwriter.xsjslib
+++ b/service/xsjslib/xmlwriter.xsjslib
@@ -22,8 +22,8 @@ var entities = {
 	"'": "&apos;",
 	"\"": "&quot;"
 };
-  
- 
+
+
 function escapeXmlText(value) {
 	if (typeof value !== "string") {
 		return value;
@@ -32,8 +32,8 @@ function escapeXmlText(value) {
 		return entities[match];
 	});
 }
-  
- 
+
+
 function escapeXmlAttribute(value) {
 	if (typeof value !== "string") {
 		return value;
@@ -42,7 +42,7 @@ function escapeXmlAttribute(value) {
 		return entities[match];
 	});
 }
-	
+
 var XmlWriter;
 XmlWriter = function(){
 	this.buffer = [];
@@ -55,7 +55,7 @@ XmlWriter.prototype = {
 		this.defaultNamespace = namespace;
 	},
 	getNsPrefix: function(namespace){
-		if (namespace === "http://www.w3.org/XML/1998/namespace" || namespace === "xml"){ 
+		if (namespace === "http://www.w3.org/XML/1998/namespace" || namespace === "xml"){
 			return "xml";
 		}
 		var namespaceStack = this.namespaceStack;
@@ -157,7 +157,7 @@ XmlWriter.prototype = {
 		if (!this.elementOpen) {
 			throw "No opened element";
 		}
-		
+
 		if (ns) {
 			ns = this.getNsPrefix(ns);
 		}
@@ -190,11 +190,11 @@ XmlWriter.prototype = {
 		this.elementStack.length = 0;
 		this.namespaceStack.length = 0;
 		this.elementOpen = false;
-	} 
+	}
 };
 
 exports.XmlWriter = XmlWriter;
 exports.escapeXmlText = escapeXmlText;
 exports.escapeXmlAttribute = escapeXmlAttribute;
-	
+
 }(this));

--- a/service/xsjslib/zip.xsjslib
+++ b/service/xsjslib/zip.xsjslib
@@ -47,7 +47,7 @@
 	  var archive = new $.util.Zip();
 	  var k;
 	  for (k in contents) {
-		  archive[k] = contents[k]
+		  archive[k] = contents[k];
 	  }
       return archive;
   }
@@ -67,7 +67,7 @@
 	  });
 	  return archive;
   }
-  
+
   function generateArchive(contents){
     var zipInterfaces = {
     	"$.util.Zip": generateArchiveWithNativeZip,


### PR DESCRIPTION
- Got rid of trailing whitespace
- Prevent variables from leaking into global scope
- Added JSHint ignore statements to the Function constructors because we are aware they are a form of eval
- Changed //fallthrough comments in switch statements to /\* falls through */ so JSHint stops warning about missing break statements
- Fixed potential syntax issues (missing semicolons, etc)
