### PR TITLE
Add BigInt aka. long aka. Int64 Support for the odatafilterparser and…

### DIFF
--- a/service/xsjslib/odatafilterparser.xsjslib
+++ b/service/xsjslib/odatafilterparser.xsjslib
@@ -116,6 +116,11 @@ var ODataFilterParser;
       "pattern": /null/,
       "type": optypes.operand
     },
+    "long": {
+        "pattern": /([-]?[0-9]+)L/,
+        "type": optypes.operand,
+        "dataType": "number"
+    },
     "number": {
       "pattern": /-?(0|[1-9]\d*)(\.\d+)?([eE][\+\-]?\d+)?/,
       "type": optypes.operand,

--- a/service/xsjslib/querybuilder.xsjslib
+++ b/service/xsjslib/querybuilder.xsjslib
@@ -251,6 +251,9 @@ limitations under the License.
 			case "identifier":
 				str += sql.checkIdentifier(node.text);
 				break;
+			case "long":
+				return parseFloat(node.text);
+				break;
 			case "number":
 			case "string":
 				str += node.text;


### PR DESCRIPTION
… query builder

If you work with column types "BigInt" your OData endpoint requires filter expressions like:
`$filter=(CD lt 1487257323585L)`

So my column is `CD` and my filter value is `1487257323585`. 

In my HANA OData implementation the endpoint wouldn't accept 
`$filter=(CD lt 1487257323585)`
because the value exceeds Integer range.

So I think odxl should support the 123L notation.